### PR TITLE
[Staging] Bind to port 6379 and respond to "PING" with "PONG" by RESP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,36 @@
-[![progress-banner](https://backend.codecrafters.io/progress/redis/e1db8ba7-ba34-4b19-a5a1-da909601dcde)](https://app.codecrafters.io/users/codecrafters-bot?r=2qF)
+# Makefile
 
-This is a starting point for Rust solutions to the
-["Build Your Own Redis" Challenge](https://codecrafters.io/challenges/redis).
+TARGET_DIR=/tmp/codecrafters-redis-target
+TARGET=$(TARGET_DIR)/release/redis-starter-rust
+MANIFEST_PATH=Cargo.toml
 
-In this challenge, you'll build a toy Redis clone that's capable of handling
-basic commands like `PING`, `SET` and `GET`. Along the way we'll learn about
-event loops, the Redis protocol and more.
+.PHONY: all build run test
 
-**Note**: If you're viewing this repo on GitHub, head over to
-[codecrafters.io](https://codecrafters.io) to try the challenge.
+all: build run
 
-# Passing the first stage
+build:
+cd $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST)))) && \
+	cargo build --release --target-dir=$(TARGET_DIR) --manifest-path=$(MANIFEST_PATH)
 
-The entry point for your Redis implementation is in `src/main.rs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+run: build
+$(TARGET) $(ARGS)
 
-```sh
-git add .
-git commit -m "pass 1st stage" # any msg
-git push origin master
-```
+kill:
+kill -9 $(shell lsof -t -i:6379)
 
-That's all!
+# 추가된 부분: .codecrafters/compile.sh 스크립트 내용
 
-# Stage 2 & beyond
+compile:
+set -e && \
+ cargo build --release --target-dir=$(TARGET_DIR) --manifest-path=$(MANIFEST_PATH)
 
-Note: This section is for stages 2 and beyond.
+# 추가된 부분: .codecrafters/run.sh 스크립트 내용
 
-1. Ensure you have `cargo (1.54)` installed locally
-1. Run `./your_program.sh` to run your Redis server, which is implemented in
-   `src/main.rs`. This command compiles your Rust project, so it might be slow
-   the first time you run it. Subsequent runs will be fast.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+run_codecrafters: compile
+set -e && \
+ exec $(TARGET) "$@"
+
+# 테스트 단계 추가
+
+test:
+cargo test

--- a/makefile
+++ b/makefile
@@ -1,33 +1,14 @@
-# Makefile
 
-TARGET_DIR=/tmp/codecrafters-redis-target
-TARGET=$(TARGET_DIR)/release/redis-starter-rust
-MANIFEST_PATH=Cargo.toml
+test:
+	codecrafters test
 
-.PHONY: all build run test
+submit:
+	git stash && git checkout master && git pull && git stash apply && \
+	codecrafters submit
 
-all: build run
-
-build:
-	cd $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST)))) && \
-	cargo build --release --target-dir=$(TARGET_DIR) --manifest-path=$(MANIFEST_PATH)
-
-run: build
-	$(TARGET) $(ARGS)
 
 kill:
 	kill -9 $(shell lsof -t -i:6379)
 
-# 추가된 부분: .codecrafters/compile.sh 스크립트 내용
-compile:
-	set -e && \
-	cargo build --release --target-dir=$(TARGET_DIR) --manifest-path=$(MANIFEST_PATH)
 
-# 추가된 부분: .codecrafters/run.sh 스크립트 내용
-run_codecrafters: compile
-	set -e && \
-	exec $(TARGET) "$@"
 
-# 테스트 단계 추가
-test:
-	cargo test

--- a/makefile
+++ b/makefile
@@ -4,7 +4,7 @@ TARGET_DIR=/tmp/codecrafters-redis-target
 TARGET=$(TARGET_DIR)/release/redis-starter-rust
 MANIFEST_PATH=Cargo.toml
 
-.PHONY: all build run
+.PHONY: all build run test
 
 all: build run
 
@@ -17,3 +17,17 @@ run: build
 
 kill:
 	kill -9 $(shell lsof -t -i:6379)
+
+# 추가된 부분: .codecrafters/compile.sh 스크립트 내용
+compile:
+	set -e && \
+	cargo build --release --target-dir=$(TARGET_DIR) --manifest-path=$(MANIFEST_PATH)
+
+# 추가된 부분: .codecrafters/run.sh 스크립트 내용
+run_codecrafters: compile
+	set -e && \
+	exec $(TARGET) "$@"
+
+# 테스트 단계 추가
+test:
+	cargo test

--- a/makefile
+++ b/makefile
@@ -6,9 +6,15 @@ submit:
 	git stash && git checkout master && git pull && git stash apply && \
 	codecrafters submit
 
+run:
+	./your_program.sh
+
 
 kill:
 	kill -9 $(shell lsof -t -i:6379)
 
 
 
+ping: 
+	echo -ne '*1\r\n$4\r\nping\r\n' | nc localhost 6379 \
+	

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::net::TcpListener;
+use std::{io::Write, net::TcpListener};
 
 fn main() {
     println!("Logs from your program will appear here!");
@@ -11,6 +11,9 @@ fn main() {
             Ok(_stream) => {
                 println!("accepted new connection");
                 println!("{:?}", _stream);
+                let mut tcp_stream = _stream;
+                let response = "+PONG\r\n";
+                tcp_stream.write(response.as_bytes()).expect("Failed to write to stream");
             }
             Err(e) => {
                 println!("error: {}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ fn main() {
         match stream {
             Ok(_stream) => {
                 println!("accepted new connection");
+                println!("{:?}", _stream);
             }
             Err(e) => {
                 println!("error: {}", e);


### PR DESCRIPTION
# Today I Learned

## 1. 기본 정보

- **Binding Port**: Redis 서버는 기본적으로 TCP 6379 포트를 사용
-  Redis generally uses RESP as a [request-response](https://redis.io/docs/latest/develop/reference/protocol-spec/#request-response-model) protocol
- **프로토콜**: [Redis Protocol (RESP2)](https://redis.io/docs/latest/develop/reference/protocol-spec/#resp-protocol-description)

## 2. RESP (Redis Serialization Protocol)

### 2.1 RESP 특징
- 다양한 데이터 타입을 지원하는 직렬화 프로토콜
- 표준 ASCII로 인코딩된 제어 시퀀스를 사용하는 이진 프로토콜
- 모든 RESP 데이터는 `\r\n` (CRLF)로 종료됨

**인코딩 예시**:
```text
A → 65 
문자 CR(\r)  → 13
LF(\n)) → 10
SP( ) → 32
```


### 2.2 RESP 데이터 타입 분류
- **simple 타입**: 단순한 리터럴 값을 나타내는 프로그래밍 언어의 스칼라와 유사 (예: Boolean, Integer)
- **Bulk(대량) 타입**: 임의의 이진 데이터를 포함할 수 있는 문자열
- **Aggregate (집계) 타입**: 여러 값을 그룹화

RESP strings are either simple or bulk. 
1. _Simple strings_ never contain carriage return (\r) or line feed (\n) characters. 
2. _Bulk strings_ can contain any binary data and may also be referred to as binary or blob. 

* Note: Bulk strings may be further encoded and decoded,  e.g. with a wide multi-byte encoding, by the client.





### 2.3 RESP 사용 방식
1. 클라이언트: [array](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays) of [bulk strings](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings) 형태로 명령 전송
   → The first byte in an RESP-serialized payload always identifies its type. 
   → Subsequent bytes constitute the type's contents.
2. 서버: RESP 타입으로 응답

## 3. Redis 명령 예시

### 3.1 SET 명령

```python
import redis
cli = redis.Redis()
cli.set('a', 'hello')
```

<img width="935" alt="image" src="https://github.com/user-attachments/assets/90a7c518-b0b4-4257-92ea-18f3ca3c76e6">


- Every line is terminated by \r\n. 
- CLIENTS start each command with a line in in the prefix `*3`
     - → It declares the command will have three parameters.
- Each parameter is two lines, $ followed by an integer 
      → It declares the number of bytes in the following line, excluding the terminating `\r\n`

<img width="934" alt="image" src="https://github.com/user-attachments/assets/5432775d-19ce-4e24-ab4f-e2731716f9d4">




**네트워크 요청:**
```
*3\r\n$3\r\nSET\r\n$1\r\nA\r\n$5\r\nhello\r\n
```

### 3.2 GET 명령

```python
cli.get('a')  # 'hello' 반환
```

**클라이언트 요청:**
```
*2\r\n$3\r\nGET\r\n$1\r\na\r\n
```






배열의 다음 요소는 명령의 인수입니다. 


**서버 응답:**
```
$5\r\nhello\r\n
```



서버는 RESP 유형으로 응답합니다. 
응답 유형은 명령어의 구현에 따라 결정되며, 클라이언트의 프로토콜 버전에 따라 결정될 수도 있습니다.




## 4. 프로토콜 구조

- 각 라인은 `\r\n`으로 종료 (The \r\n (CRLF) is the protocol's terminator, which always separates its parts.)
- 명령은 `*`로 시작하며, 뒤에 파라미터 수가 옴
- 각 파라미터는 `$`로 시작하고, 뒤에 바이트 수가 옴

## 5. 테스트

1. local 테스트 명령어:
```bash
echo -ne '*1\r\n$4\r\nping\r\n' | nc localhost 6379
```
2. [codecrafts cli](https://docs.codecrafters.io/cli/installation)

<img width="771" alt="image" src="https://github.com/user-attachments/assets/63fd4dfe-90dd-465d-8970-2f569fdbf07e">


<img width="836" alt="image" src="https://github.com/user-attachments/assets/95bff16a-3d2f-43b3-a4d5-666689ab8e6d">



## 참고 자료

- [Redis 공식 문서 - 프로토콜 명세](https://redis.io/docs/latest/develop/reference/protocol-spec/)
- [Redis 프로토콜 설명](https://lethain.com/redis-protocol/)
- [Redis PING 명령](https://redis.io/docs/latest/commands/ping/)
- [Redis python code 출처](https://lethain.com/redis-protocol/)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced the `README.md` with detailed instructions for building, running, and testing the Redis clone project using a structured Makefile format.

- **New Features**
  - Introduced new Makefile targets for `kill`, `compile`, `test`, and `submit`, facilitating improved operations and version control.

- **Improvements**
  - Updated TCP server functionality to log connection details and respond with a "+PONG" message, enhancing interactivity with clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->