### PR TITLE
[Staging] Respond to multiple PINGs

### DIFF
--- a/makefile
+++ b/makefile
@@ -14,7 +14,9 @@ kill:
 	kill -9 $(shell lsof -t -i:6379)
 
 
-
-ping: 
-	echo -ne '*1\r\n$4\r\nping\r\n' | nc localhost 6379 \
 	
+ping: 
+	echo -ne '*1\r\n$4\r\nping\r\n' | nc localhost 6379 
+
+multi-ping:
+	echo -e "PING\nPING"  | nc localhost 6379 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,23 +1,40 @@
-use std::{io::Write, net::TcpListener};
+use std::{io::{Read, Write}, net::TcpListener};
 
 fn main() {
-    println!("Logs from your program will appear here!");
+	println!("Logs from your program will appear here!");
 
-    
-    let listener = TcpListener::bind("127.0.0.1:6379").unwrap();
-    
-    for stream in listener.incoming() {
-        match stream {
-            Ok(_stream) => {
-                println!("accepted new connection");
-                println!("{:?}", _stream);
-                let mut tcp_stream = _stream;
-                let response = "+PONG\r\n";
-                tcp_stream.write(response.as_bytes()).expect("Failed to write to stream");
-            }
-            Err(e) => {
-                println!("error: {}", e);
-            }
-        }
-    }
+	
+	let listener = TcpListener::bind("127.0.0.1:6379").expect("Failed to bind to port 6379");
+	
+	for stream in listener.incoming() {
+		match stream {
+			Ok(stream) => {
+				println!("accepted new connection");
+				println!("{:?}", stream);
+				let mut tcp_stream = stream;
+				let response = "+PONG\r\n";
+
+				let mut buffer = [0; 1024];
+
+				loop {
+					match tcp_stream.read(&mut buffer) {
+						Ok(0) => break,
+						Ok(_) => {
+							println!("read from stream: {}", String::from_utf8_lossy(&buffer));
+							tcp_stream.write(response.as_bytes()).expect("Failed to write to stream");
+						}
+						Err(e) => {
+							println!("multiple Ping response error: {}", e);
+							break;
+						}
+					}
+				}
+
+				println!("read from stream: {}", String::from_utf8_lossy(&buffer));
+			}
+			Err(e) => {
+				println!("error: {}", e);
+			}
+		}
+	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,6 @@ fn main() {
 					match tcp_stream.read(&mut buffer) {
 						Ok(0) => break,
 						Ok(_) => {
-							println!("read from stream: {}", String::from_utf8_lossy(&buffer));
 							tcp_stream.write(response.as_bytes()).expect("Failed to write to stream");
 						}
 						Err(e) => {


### PR DESCRIPTION
# WIP (Documenting) 
ref:
### TCP server in Rust using the std::net module.
https://doc.rust-lang.org/std/net/index.html

Relative to: #3 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `multi-ping` target in the Makefile for improved efficiency in network checks with the Redis server.
  - Enhanced TCP server functionality to handle multiple requests from a single connection, improving responsiveness.

- **Bug Fixes**
  - Improved error handling and logging for read errors in the TCP server.

- **Style**
  - Minor whitespace adjustments in the Makefile for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->