### PR TITLE
[Replication] feat: add feature configuring the Redis server port through command-line arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,16 @@
 mod client;
 
+use std::env;
+
 use client::connection::RedisServer;
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
     println!("Redis 서버 시작 중...");
 
-    let server = RedisServer::new("127.0.0.1".to_string(), 6379);
+    let port: u16 = env::args().nth(2).unwrap_or("6379".to_string()).parse().unwrap();
+
+
+    let server = RedisServer::new("127.0.0.1".to_string(), port);
     server.run().await
 }


### PR DESCRIPTION
- args: ["/tmp/codecrafters-redis-target/release/redis-starter-rust", "--port", "6389"]
- https://redis.io/docs/latest/operate/oss_and_stack/management/replication/
- https://app.codecrafters.io/courses/redis/stages/bw1

> Documenting will be soon

related to: #10 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced flexibility by allowing users to specify the Redis server port through command-line arguments, defaulting to `6379` if none is provided.

- **Bug Fixes**
  - Improved usability in various deployment scenarios by ensuring the application can adapt to different server port configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->